### PR TITLE
Fix config.ini parser in file-preprocessing.sh

### DIFF
--- a/src/file-preprocessing.sh
+++ b/src/file-preprocessing.sh
@@ -2,7 +2,7 @@
 
 # Read data_text_dir path from a config file.
 CURDIR=$(cd $(dirname $0); pwd)
-source <(grep TEXTDIR ${CURDIR}/../config.ini | sed 's/ *= */=/g')
+source <(sed -n '/^\[DATA\]/,/^\[/p' ${CURDIR}/../config.ini | grep TEXTDIR | sed 's/ *= */=/g')
 
 # Text preprocessing.
 # 1-1. Remove blank lines.


### PR DESCRIPTION
config.ini contains multiple `TEXTDIR` entries.
file-preprocessing.sh should read one from `[DATA]` section, instead of `[FINETUNING-DATA]` section.