### PR TITLE
Fix path to WikiExtractor.py

### DIFF
--- a/src/data-download-and-extract.py
+++ b/src/data-download-and-extract.py
@@ -38,7 +38,7 @@ def download():
 
 def extract():
     subprocess.call(['python3', 
-                    os.path.join(CURDIR, os.pardir, os.pardir, 
+                    os.path.join(CURDIR, os.pardir,
                                  'wikiextractor', 'WikiExtractor.py'), 
                     FILEPATH, "-o={}".format(EXTRACTDIR)])
 


### PR DESCRIPTION
README.md に書いてある通りにコマンドを実行した場合のパスが合うように修正
$ python3 src/data-download-and-extract.py